### PR TITLE
docs: cross-reference standra ecosystem + spec 009 additive fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ Spec in development. Used in production for multi-agent AI coding dispatch.
 
 See benchmark compliance rates on [ServingCard](https://servingcard.dev).
 
+## Ecosystem
+
+CACP is part of the [standra.ai](https://standra.ai) open standards stack:
+
+- **[Axiom](https://github.com/zenprocess/axiom)** — Rule Definition Language; CACP is one of two normative serializations (alongside TOON). Axiom §17 standardizes orchestration shape vocabulary, complexity tier vocabulary, `fixture_gap` status, `verification_runs[]`, and `artifact_quality` schemas that CACP responses can carry.
+- **[Pawbench](https://github.com/zenprocess/pawbench)** — reference benchmark that scores LLMs against CACP-formatted prompts and responses, including the orchestration × complexity matrix.
+- **[ServingCard](https://servingcard.dev)** — model serving config standard.
+
+## Recent additive fields (spec 009)
+
+CACP responses can carry these spec 009 fields (see [switchyard spec 009](https://github.com/zenprocess/switchyard/blob/main/specs/009-pawbench-orchestration-axis/spec.md) for the operational mapping):
+
+- `complexity_tier` — `display` / `crud` / `transactional` / `cross_cutting`
+- `verification_runs[]` — N-run AC re-verification with per-run verdict + prompt hash
+- `artifact_quality` — static-analysis score over changed files
+- `fixture_gap` (status) — AC un-evaluable due to missing setup, NOT counted against the agent
+
 ## License
 
 MIT


### PR DESCRIPTION
Audit follow-up. The CACP README didn't cross-reference Axiom/Pawbench/ServingCard despite being part of the same ecosystem, and didn't mention the orchestration × complexity additive fields it now supports.

- **Ecosystem** section linking Axiom (RDL standard, §17 stratification), Pawbench (reference benchmark), and ServingCard
- **Additive fields for orchestration & complexity reporting** section: `complexity_tier`, `verification_runs[]`, `artifact_quality`, `fixture_gap` status

Docs only.
