### PR TITLE
ci: add docs CI workflow (link check + leak guard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
             --exclude-loopback
             --max-redirects 5
             --accept '200..=204,206,301..=308,403,429'
+            --exclude 'github.com/zenprocess/switchyard'
             './**/*.md'
           fail: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           args: >-
             --no-progress
-            --exclude-mail
+            
             --exclude-loopback
             --max-redirects 5
             --accept '200..=204,206,301..=308,403,429'
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          PATTERN='UNKNOWN @ file://|/home/[a-z][a-z0-9_-]+/(orchestrator|models)/|sk-ant-api03-[A-Za-z0-9_-]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY'
+          PATTERN='UNKNOWN @ file://|/home/[a-z][a-z0-9_-]+/(orchestrator|models)/|sk-ant-api03-[A-Za-z0-9_-]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|-----BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----'
           if git ls-files | grep -vE '^\.github/workflows/' | xargs -r grep -EHn "$PATTERN" 2>/dev/null; then
             echo "::error::Leak guard found suspicious patterns above"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lychee link check
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --exclude-mail
+            --exclude-loopback
+            --max-redirects 5
+            --accept '200..=204,206,301..=308,403,429'
+            './**/*.md'
+          fail: true
+
+  leak-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan for accidental leaks
+        shell: bash
+        run: |
+          set -e
+          PATTERN='UNKNOWN @ file://|/home/[a-z][a-z0-9_-]+/(orchestrator|models)/|sk-ant-api03-[A-Za-z0-9_-]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY'
+          if git ls-files | grep -vE '^\.github/workflows/' | xargs -r grep -EHn "$PATTERN" 2>/dev/null; then
+            echo "::error::Leak guard found suspicious patterns above"
+            exit 1
+          fi
+          echo "Leak guard clean"


### PR DESCRIPTION
Adds a minimal CI workflow for this docs-only repo.

## Jobs
- **links** — Lychee link check on all `*.md` files. Catches broken cross-references inside the standra ecosystem when a peer repo moves a path.
- **leak-guard** — regex scan for editable-install pseudo-pins, `/home/<user>/` paths, API key prefixes, and private key headers.

The leak-guard template is the same one being added to afterburn, cacp, standra, and axiom in parallel as a drop-in. Two leaks were found in the ecosystem audit (`/home/vvladescu/...` paths in axiom bench traces and servingcard registry YAMLs); this regression-tests against that pattern recurring.